### PR TITLE
Update link to docs in ~/etcd3-multinode/README.md

### DIFF
--- a/contrib/systemd/etcd3-multinode/README.md
+++ b/contrib/systemd/etcd3-multinode/README.md
@@ -20,7 +20,7 @@ In each machine, write etcd systemd service files:
 cat > /tmp/my-etcd-1.service <<EOF
 [Unit]
 Description=etcd
-Documentation=https://github.com/coreos/etcd
+Documentation=https://etcd.io/docs/
 Conflicts=etcd.service
 Conflicts=etcd2.service
 
@@ -51,7 +51,7 @@ sudo mv /tmp/my-etcd-1.service /etc/systemd/system/my-etcd-1.service
 cat > /tmp/my-etcd-2.service <<EOF
 [Unit]
 Description=etcd
-Documentation=https://github.com/coreos/etcd
+Documentation=https://etcd.io/docs/
 Conflicts=etcd.service
 Conflicts=etcd2.service
 
@@ -82,7 +82,7 @@ sudo mv /tmp/my-etcd-2.service /etc/systemd/system/my-etcd-2.service
 cat > /tmp/my-etcd-3.service <<EOF
 [Unit]
 Description=etcd
-Documentation=https://github.com/coreos/etcd
+Documentation=https://etcd.io/docs/
 Conflicts=etcd.service
 Conflicts=etcd2.service
 


### PR DESCRIPTION
updating the link to the documentation to `https://etcd.io/docs/` in `~/etcd3-multinode/README.md`


Please read https://github.com/etcd-io/etcd/blob/main/CONTRIBUTING.md#contribution-flow.
